### PR TITLE
Changed Yeoman version to eliminate error

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "~1.12.0"
   },
   "peerDependencies": {
-    "yo": ">=1.0.0-rc.1"
+    "yo": ">=1.0.0"
   },
   "engines": {
     "node": ">=0.9.9",


### PR DESCRIPTION
I changed the yeoman version to 1.0.0 in order to eliminate the error of UNMET DEPENDENCY caused by the RC version used in your package.json file while installing. Even though the generator works perfectly the error shows anyways and might mislead users.
