### PR TITLE
Using last plugman version to fix generator rather than git repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "yeoman-generator": "~0.13.0",
-    "plugman": "git://github.com/apache/cordova-plugman.git#ce8c421481ff04e87eaf81442e9504b6358c13c3"
+    "plugman": "~1.3.0"
   },
   "devDependencies": {
     "mocha": "~1.12.0"


### PR DESCRIPTION
Using last plugman version to fix generator issues that created the java files with the wrong name and prevent compilation rather than git repository
